### PR TITLE
Fix 5.14 segfaults, track eval code again

### DIFF
--- a/quickcover.xs
+++ b/quickcover.xs
@@ -148,11 +148,11 @@ static void qc_peep(pTHX_ OP *o)
          * PL_check[OP_NEXTSTATE] override, but guess what? Perl does
          * not call the check hook for OP_NEXTSTATE/DBSTATE
          */
-        if (PL_compcv && o == CvSTART(PL_compcv))
+        if (PL_compcv && o == CvSTART(PL_compcv) && CvROOT(PL_compcv))
             scan_optree(aTHX_ cover, CvROOT(PL_compcv));
-        else if (o == PL_main_start)
+        else if (o == PL_main_start && PL_main_root)
             scan_optree(aTHX_ cover, PL_main_root);
-        else if (o == PL_eval_start)
+        else if (o == PL_eval_start && PL_eval_root)
             scan_optree(aTHX_ cover, PL_eval_root);
     }
 }

--- a/quickcover.xs
+++ b/quickcover.xs
@@ -127,10 +127,6 @@ static void qc_peep(pTHX_ OP *o)
 
     peepp_orig(aTHX_ o);
 
-    /* don't track eval STRING source code */
-    if (PL_in_eval && !(PL_in_eval & EVAL_INREQUIRE))
-        return;
-
     if (enabled) {
         /* Create data structure if necessary. */
         if (!cover) {

--- a/quickcover.xs
+++ b/quickcover.xs
@@ -122,6 +122,9 @@ static OP* qc_nextstate(pTHX) {
 
 static void qc_peep(pTHX_ OP *o)
 {
+    if (!o || o->op_opt)
+        return;
+
     peepp_orig(aTHX_ o);
 
     /* don't track eval STRING source code */


### PR DESCRIPTION
I changed my mind about tracking eval STRING code: I originally wanted to reduce clutter, but I did not remember that Mason uses eval STRING to load compiled code (and the code has proper #line directives, so the coverage is going to be useful).
