### PR TITLE
Remove File::Slurp in favor of Path::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,13 +21,13 @@ WriteMakefile(
         'File::ShareDir'        => 0,
         'File::Copy'            => 0,
         'File::Spec'            => 0,
-        'File::Slurp'            => 0,
+        'Path::Tiny'            => 0,
     },
     TEST_REQUIRES  => {
         'Test::More'            => 0,
         'Test::Builder::Module' => 0,
         'File::Temp'            => 0,
-        'File::Slurp'           => 0,
+        'Path::Tiny'            => 0,
         'Data::Dumper'          => 0,
     },
     CONFIGURE_REQUIRES => {

--- a/lib/Devel/QuickCover/Report.pm
+++ b/lib/Devel/QuickCover/Report.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use JSON::XS    qw(encode_json   decode_json);
 use Sereal      qw(encode_sereal decode_sereal);
-use File::Slurp qw(read_file     write_file);
+use Path::Tiny  qw(path);
 
 sub new {
     my ($class) = @_;
@@ -23,7 +23,7 @@ sub new {
 sub load {
     my ($self, $file) = @_;
 
-    my $data = read_file($file, { binmode => ':raw', err_mode => 'croak' });
+    my $data = path($file)->slurp_raw;
     my $decoded = Sereal::decode_sereal($data);
 
     if (exists $decoded->{files}) {
@@ -41,14 +41,14 @@ sub save {
     my ($self, $file) = @_;
 
     my $encoded = Sereal::encode_sereal($self->{data});
-    write_file($file, { binmode => ':raw', err_mode => 'croak' }, $encoded);
+    path($file)->spew_raw($encoded);
     $self->{changes} = 0;
 }
 
 sub merge {
     my ($self, $file) = @_;
 
-    my $json = read_file($file, { err_mode => 'croak' });
+    my $json = path($file)->slurp;
     my $decoded = decode_json($json);
     my $files = $self->{data}{files};
 

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -1,7 +1,6 @@
 use t::lib::Test;
 
 use JSON::XS    qw(encode_json   decode_json);
-use File::Slurp qw(read_file     write_file);
 use File::Temp  qw(tempdir);
 
 my $dir;

--- a/t/lib/Test.pm
+++ b/t/lib/Test.pm
@@ -1,10 +1,12 @@
 package t::lib::Test;
-
+use strict;
+use warnings;
 use parent 'Test::Builder::Module';
 
+use Data::Dumper;
 use Test::More;
 use JSON::XS    qw( decode_json );
-use File::Slurp qw( read_file );
+use Path::Tiny  qw( path );
 
 our @EXPORT= (
      @Test::More::EXPORT,
@@ -12,7 +14,7 @@ our @EXPORT= (
         read_report
         get_coverage_from_report
         parse_fixture
-     )
+     ),
 );
 
 sub import {
@@ -33,7 +35,7 @@ sub read_report {
 
     my ($fname) =  @files;
 
-    my $json = read_file($fname)
+    my $json = path($fname)->slurp
         or return;
 
     my $decoded = decode_json($json)
@@ -47,16 +49,13 @@ sub get_coverage_from_report {
 
     my $lines = $report->{files}{$file};
 
-    return $lines
+    return $lines;
 }
 
 sub parse_fixture {
     my $file = shift;
 
-    my $content = read_file($file);
-    my @lines = split /\n/, $content;
-
-    use Data::Dumper;
+    my @lines = path($file)->lines;
 
     my @expected =
         map  +($_->[0]),                         # linenos


### PR DESCRIPTION
File::Slurp has a few issues associated with it[1], while
Path::Tiny is clean and accurate. It has more dependencies,
but it does things correctly and is actively maintained.

[1] https://rt.cpan.org/Dist/Display.html?Name=File-Slurp
