### PR TITLE
Cleanup various things

### DIFF
--- a/lib/Devel/QuickCover.pm
+++ b/lib/Devel/QuickCover.pm
@@ -2,7 +2,7 @@ package Devel::QuickCover;
 
 use strict;
 use warnings;
-
+use Carp 'croak';
 use XSLoader;
 
 our $VERSION = '0.600100';
@@ -21,7 +21,8 @@ our %CONFIG;
 sub import {
     my ($class, @opts) = @_;
 
-    die "Invalid argument to import, it takes key-value pairs. FOO => BAR" if 1 == @opts % 2;
+    croak("Invalid argument to import, it takes key-value pairs. FOO => BAR")
+        if 1 == @opts % 2;
     my %options = @opts;
 
     %CONFIG = %DEFAULT_CONFIG;
@@ -32,7 +33,7 @@ sub import {
     }
 
     if (keys %options > 0) {
-        die "Invalid import option(s): " . join(',', keys %options) ;
+        croak("Invalid import option(s): " . join(',', keys %options));
     }
 
     if (!$CONFIG{'nostart'}) {

--- a/lib/Devel/QuickCover.pm
+++ b/lib/Devel/QuickCover.pm
@@ -13,7 +13,7 @@ my %DEFAULT_CONFIG = (
     noatexit         => 0,      # Don't register an atexit handler to dump and cleanup
     nostart          => 0,      # Don't start gathering coverage information on import
     nodump           => 0,      # Don't dump the coverage report at the END of the program
-    output_directory => "/tmp", # Write report to that directory
+    output_directory => '/tmp', # Write report to that directory
     metadata         => {}    , # Additional context information
 );
 our %CONFIG;
@@ -21,7 +21,7 @@ our %CONFIG;
 sub import {
     my ($class, @opts) = @_;
 
-    croak("Invalid argument to import, it takes key-value pairs. FOO => BAR")
+    croak('Invalid argument to import, it takes key-value pairs. FOO => BAR')
         if 1 == @opts % 2;
     my %options = @opts;
 
@@ -33,7 +33,7 @@ sub import {
     }
 
     if (keys %options > 0) {
-        croak("Invalid import option(s): " . join(',', keys %options));
+        croak('Invalid import option(s): ' . join ',', keys %options);
     }
 
     if (!$CONFIG{'nostart'}) {

--- a/lib/Devel/QuickCover/Report/Html.pm
+++ b/lib/Devel/QuickCover/Report/Html.pm
@@ -141,7 +141,7 @@ sub _render_file {
     my $source = $self->_fetch_source($item);
 
     return unless $source;
-    my $lines = ['I hope you never shee this...', split /\n/, $source];
+    my $lines = ['I hope you never see this...', split /\n/, $source];
 
     $self->_write_template(
         $TEMPLATES{file},

--- a/lib/Devel/QuickCover/Report/Html.pm
+++ b/lib/Devel/QuickCover/Report/Html.pm
@@ -166,7 +166,7 @@ sub _fetch_source {
             $item->{git_prefix}, $item->{git_repository}, $item->{git_commit},
         );
         my $source = $fetcher->fetch($item->{file_name});
-        return $source ? $$source : undef;;
+        return $source ? $$source : undef;
     }
 
     return undef unless -f $item->{file_name};

--- a/lib/Devel/QuickCover/Report/Html.pm
+++ b/lib/Devel/QuickCover/Report/Html.pm
@@ -10,7 +10,7 @@ use File::Copy;
 use File::ShareDir;
 use File::Spec::Functions;
 use IO::Compress::Gzip;
-use POSIX;
+use POSIX qw(strftime);
 use Text::MicroTemplate;
 
 our $VERSION = '0.01';

--- a/lib/Devel/QuickCover/Report/Html.pm
+++ b/lib/Devel/QuickCover/Report/Html.pm
@@ -189,7 +189,7 @@ sub _get_template {
     my $path = File::ShareDir::dist_file('Devel-QuickCover', $basename);
     my $tmpl = do {
         local $/;
-        open my $fh, '<:utf8', $path or die "Unable to open '$path': $!";
+        open my $fh, '<:encoding(UTF-8)', $path or die "Unable to open '$path': $!";
         readline $fh;
     };
 


### PR DESCRIPTION
- Use `croak` instead of `die`.
- Explicit minimal import.
- Typo fixes (including two semicolons).
- Correct IO layer to prevent lack of checking.

This is based off **master**, so if #12 is merged, this should be rebased off that. I would be happy to do that. This can be merged first and then #12 should be rebased. Of course they can both be merged without rebasing but meh.

I leave it as PR in case someone disagrees.
