### PR TITLE
Improve documentation and add script help messages

### DIFF
--- a/bin/qc-aggregate.pl
+++ b/bin/qc-aggregate.pl
@@ -4,6 +4,7 @@
 
 use strict;
 use warnings;
+use Getopt::Long;
 
 use Devel::QuickCover::Report;
 
@@ -12,9 +13,32 @@ my $QC_PATH       = '/tmp';
 my $QC_PREFIXES   = 'QC';      # Could be '(QC|CQ|XX)'
 my $QC_EXTENSIONS = 'txt';     # Could be '(txt|dat|db)'
 
+my $HELP_MSG =<<END;
+qc-aggregate.pl - Aggregate Devel::QuickCover cover files
+
+USE:
+
+    qc-aggregate.pl
+
+DESCRIPTION:
+
+qc-aggregate.pl aggregates all Devel::QuickCover files $QC_PATH/$QC_PREFIXES_\*.$QC_EXTENSIONS
+into a Sereal database that can be converted into Devel::Cover output.
+The data is written to $QC_DATABASE. If this file exists, the new data
+is added to it.
+END
+
 exit main();
 
 sub main {
+    my %options = ();
+    GetOptions(\%options, 'help|h');
+
+    if (defined $options{help}) {
+        print $HELP_MSG;
+        return 0;
+    }
+
     my $report = Devel::QuickCover::Report->new;
 
     $report->load($QC_DATABASE)

--- a/bin/qc-aggregate.pl
+++ b/bin/qc-aggregate.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Aggregate a bunch of cover files into a Sereal "database".
 

--- a/bin/qc-html.pl
+++ b/bin/qc-html.pl
@@ -17,11 +17,30 @@ my $QC_DATABASE   = 'qc.dat';
 my $COVERDB       = './cover_db/';
 my $VERBOSE       = 0;
 my %PATH_REWRITES = ();
+my $HELP;
+my $HELP_MSG =<<END;
+qc-html.pl - Generate a Devel::Cover-compatible report file from cover data.
+
+USE:
+
+    qc-html.pl [OPTION...]
+
+By default, qc-html.pl reads data from the Devel::QuickCover database
+$QC_DATABASE and writes its output to the folder $COVERDB.
+
+OPTIONS:
+
+    --input         Devel::QuickCover database to read from. Default $QC_DATABASE.
+    --cover-db      Devel::Cover database to write to. Default $COVERDB.
+    --verbose       Verbose level. Default 0.
+    -h, --help      Print this message and exit.
+END
 
 GetOptions('input=s'         => \$QC_DATABASE,
            'cover-db=s'      => \$COVERDB,
            'verbose=i'       => \$VERBOSE,
            'path-rewrite=s%' => \%PATH_REWRITES,
+           'h|help'          => \$HELP,
 );
 
 my $DIGESTS       = "$COVERDB/digests";
@@ -36,6 +55,11 @@ $ENV{DEVEL_COVER_DB_FORMAT}
 exit main();
 
 sub main {
+    if (defined $HELP) {
+        print $HELP_MSG;
+        return 0;
+    }
+
     my $report = load_data($QC_DATABASE);
 
     make_coverdb_directories();

--- a/lib/Devel/QuickCover.pm
+++ b/lib/Devel/QuickCover.pm
@@ -116,6 +116,21 @@ When you call C<end()>, you can optionally pass a C<nodump>
 boolean argument, to indicate whether you wish to skip generating
 the cover files.
 
+=head1 Use with Devel::Cover
+
+Devel::QuickCover is distributed with the scripts qc-aggregate.pl and
+qc-html.pl that can be used to convert its output into a format that
+Devel::Cover understands. Once you have generated your coverage reports,
+aggregate them by running
+
+    qc-aggregate.pl
+
+and convert them into the Devel::Cover database format by running
+
+    qc-html.pl
+
+Then you can view the reports with the standard Devel::Cover tools.
+
 =head1 AUTHORS
 
 =over 4


### PR DESCRIPTION
I added a description of how to view the package coverage reports with
the Devel::Cover package to the POD documentation. I also added
-h,--help options to qc-aggregate.pl and qc-html.pl that describe how to
use the programs and their options.

Also made qc-aggregate.pl use /usr/bin/env to find the Perl interpreter.

Note that I didn't document the --path-rewrite option of qc-html, as I'm
not quite sure what its use case is.
