### PR TITLE
Replace JSON::XS with JSON::MaybeXS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile(
     PREREQ_PM      => {
         'perl'                  => '5.014',
         'XSLoader'              => 0,
-        'JSON::XS'              => 0,
+        'JSON::MaybeXS'         => 0,
         'Sereal'                => 0,
         'IO::Compress::Gzip'    => 0,
         'IPC::Open2'            => 0,

--- a/bin/qc-html.pl
+++ b/bin/qc-html.pl
@@ -9,7 +9,7 @@ use Digest::MD5 qw(md5_hex);
 use File::Path qw(make_path);
 use Path::Tiny qw(path);
 use Getopt::Long;
-use JSON::XS;
+use JSON::MaybeXS;
 use Sereal qw(encode_sereal decode_sereal);
 use Devel::QuickCover::Report;
 
@@ -47,7 +47,7 @@ my $DIGESTS       = "$COVERDB/digests";
 my $STRUCTURE     = "$COVERDB/structure/";
 my $RUNS          = "$COVERDB/runs/";
 
-my $JSON          = JSON::XS->new->utf8->indent;
+my $JSON          = JSON::MaybeXS->new->utf8->indent;
 my $DEVEL_COVER_DB_FORMAT = 'Sereal';
 $ENV{DEVEL_COVER_DB_FORMAT}
     and $DEVEL_COVER_DB_FORMAT = 'JSON';

--- a/lib/Devel/QuickCover/Report.pm
+++ b/lib/Devel/QuickCover/Report.pm
@@ -3,9 +3,9 @@ package Devel::QuickCover::Report;
 use strict;
 use warnings;
 
-use JSON::XS    qw(encode_json   decode_json);
-use Sereal      qw(encode_sereal decode_sereal);
-use Path::Tiny  qw(path);
+use JSON::MaybeXS qw(encode_json   decode_json);
+use Sereal        qw(encode_sereal decode_sereal);
+use Path::Tiny    qw(path);
 
 sub new {
     my ($class) = @_;

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -1,7 +1,7 @@
 use t::lib::Test;
 
-use JSON::XS    qw(encode_json   decode_json);
-use File::Temp  qw(tempdir);
+use JSON::MaybeXS qw(encode_json   decode_json);
+use File::Temp    qw(tempdir);
 
 my $dir;
 BEGIN {

--- a/t/lib/Test.pm
+++ b/t/lib/Test.pm
@@ -5,8 +5,8 @@ use parent 'Test::Builder::Module';
 
 use Data::Dumper;
 use Test::More;
-use JSON::XS    qw( decode_json );
-use Path::Tiny  qw( path );
+use JSON::MaybeXS qw( decode_json );
+use Path::Tiny    qw( path );
 
 our @EXPORT= (
      @Test::More::EXPORT,


### PR DESCRIPTION
While it's not like you can use this module without XS it is still
preferable to give people the choice of which JSON module to use.
Some people like myself would prefer to use Cpanel::JSON::XS.

JSON::MaybeXS is the current favoured compatibility layer above
the various JSON backends. It used to be JSON, then JSON::Any,
now this. It is used by a few hundred modules on CPAN including
other modules in a similar area like Devel::Cover & Devel::NYTProf.